### PR TITLE
PVE001: Restrict scope of _rateScale

### DIFF
--- a/contracts/reward/pools/ControlledRewardPool.sol
+++ b/contracts/reward/pools/ControlledRewardPool.sol
@@ -23,7 +23,7 @@ abstract contract ControlledRewardPool is IManagedRewardPool {
   IRewardController internal _controller;
 
   uint256 private _pausedRate;
-  uint224 internal _rateScale;
+  uint224 private _rateScale;
   uint16 private _baselinePercentage;
   bool private _paused;
 
@@ -131,7 +131,7 @@ abstract contract ControlledRewardPool is IManagedRewardPool {
     internalSetRateScale(rateScale);
   }
 
-  function getRateScale() external view returns (uint256) {
+  function getRateScale() public view returns (uint256) {
     return _rateScale;
   }
 

--- a/contracts/reward/pools/TokenWeightedRewardPoolV1.sol
+++ b/contracts/reward/pools/TokenWeightedRewardPoolV1.sol
@@ -36,11 +36,12 @@ contract TokenWeightedRewardPoolV1 is
   }
 
   function initializedWith() external view override returns (InitData memory) {
+    uint256 rateScale = getRateScale();
     return
       InitData(
         _controller,
-        internalGetRate().rayDiv(_rateScale),
-        _rateScale,
+        internalGetRate().rayDiv(rateScale),
+        uint224(rateScale), // no overflow as getRateScale() is uint224 inside
         getBaselinePercentage()
       );
   }


### PR DESCRIPTION
After this change _rateScale is not directly accessible to descendants. 
It is only set with constructor/initializer, hence can be considered a constant. 
This resolves PVE001.